### PR TITLE
Update GHA workflow to use docker actions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,19 +8,46 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMAGE_NAME: gitlab-runner-machine-hetzner
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
+    name: Build image
+
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out repository for metadata
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
       - name: Identify version to build
+        id: version-meta
         run: |
-          egrep "^ARG DOCKER_MACHINE_DRIVER_HETZNER_VERSION=" Dockerfile | sed "s|^ARG ||" >> $GITHUB_ENV
-          echo "GITLAB_RUNNER_VERSION=$(egrep "^FROM gitlab/gitlab-runner:" Dockerfile | awk '{print $2}' | cut -d: -f2 | cut -d@ -f1)" >> $GITHUB_ENV
+          egrep "^ARG DOCKER_MACHINE_DRIVER_HETZNER_VERSION=" Dockerfile | sed "s|^ARG ||" | tee -a $GITHUB_OUTPUT
+          echo "GITLAB_RUNNER_VERSION=$(egrep "^FROM gitlab/gitlab-runner:" Dockerfile | awk '{print $2}' | cut -d: -f2 | cut -d@ -f1)" | tee -a $GITHUB_OUTPUT
 
-      - name: Build image
-        run: docker build . --file Dockerfile --tag "$IMAGE_NAME" --cache-from "ghcr.io/${{ github.repository }}/$IMAGE_NAME:latest"
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # set latest tag for default branch
+            type=raw,value=latest,enable=true
+            type=raw,value=${{
+              steps.version-meta.outputs.GITLAB_RUNNER_VERSION
+            }}-machine-hetzner-v${{
+              steps.version-meta.outputs.DOCKER_MACHINE_DRIVER_HETZNER_VERSION
+            }},enable=true
+
+      - name: Build Docker image
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
+        with:
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          cache-from: ${{ steps.custom-meta.outputs.base-image-name }}:buildcache
+        env:
+          SOURCE_DATE_EPOCH: 0

--- a/.github/workflows/docker-publish-latest.yml
+++ b/.github/workflows/docker-publish-latest.yml
@@ -11,41 +11,59 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMAGE_NAME: gitlab-runner-machine-hetzner
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   push:
+    name: Build and publish image
+
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    timeout-minutes: 10
+
+    permissions:
+      contents: read
+      packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out repository for metadata
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
       - name: Identify version to build
+        id: version-meta
         run: |
-          egrep "^ARG DOCKER_MACHINE_DRIVER_HETZNER_VERSION=" Dockerfile | sed "s|^ARG ||" >> $GITHUB_ENV
-          echo "GITLAB_RUNNER_VERSION=$(egrep "^FROM gitlab/gitlab-runner:" Dockerfile | awk '{print $2}' | cut -d: -f2 | cut -d@ -f1)" >> $GITHUB_ENV
+          egrep "^ARG DOCKER_MACHINE_DRIVER_HETZNER_VERSION=" Dockerfile | sed "s|^ARG ||" | tee -a $GITHUB_OUTPUT
+          echo "GITLAB_RUNNER_VERSION=$(egrep "^FROM gitlab/gitlab-runner:" Dockerfile | awk '{print $2}' | cut -d: -f2 | cut -d@ -f1)" | tee -a $GITHUB_OUTPUT
 
-      - name: Build image
-        run: docker build . --file Dockerfile --tag "$IMAGE_NAME" --cache-from "ghcr.io/${{ github.repository }}/$IMAGE_NAME:latest"
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # set latest tag for default branch
+            type=raw,value=latest,enable=true
+            type=raw,value=${{
+              steps.version-meta.outputs.GITLAB_RUNNER_VERSION
+            }}-machine-hetzner-v${{
+              steps.version-meta.outputs.DOCKER_MACHINE_DRIVER_HETZNER_VERSION
+            }},enable=true
 
-      - name: Log into registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+      - name: Log in to GHCR
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push image
-        run: |
-          IMAGE_ID="ghcr.io/${{ github.repository }}/$IMAGE_NAME"
-
-          # Change all uppercase to lowercase
-          IMAGE_ID="$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')"
-
-          IMAGE_ID_VERSIONED="${IMAGE_ID}:${GITLAB_RUNNER_VERSION}-machine-hetzner-v${DOCKER_MACHINE_DRIVER_HETZNER_VERSION}"
-
-          # Use Docker `latest` tag convention
-          echo IMAGE_ID="$IMAGE_ID"
-          echo IMAGE_ID_VERSIONED="$IMAGE_ID_VERSIONED"
-
-          docker tag "$IMAGE_NAME" "$IMAGE_ID_VERSIONED"
-          docker tag "$IMAGE_NAME" "$IMAGE_ID:latest"
-          docker push "$IMAGE_ID_VERSIONED"
-          docker push "$IMAGE_ID:latest"
+      - name: Build and push Docker image to GHCR
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
+        with:
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          push: true
+          cache-from: ${{ steps.custom-meta.outputs.base-image-name }}:buildcache
+          cache-to: ${{ steps.custom-meta.outputs.base-image-name }}:buildcache
+        env:
+          SOURCE_DATE_EPOCH: 0

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,4 @@
-Images can be pulled from `ghcr.io/n4y-docker/gitlab-runner-machine-hetzner/gitlab-runner-machine-hetzner`.
+Images were previously published to `ghcr.io/n4y-docker/gitlab-runner-machine-hetzner/gitlab-runner-machine-hetzner`.  
+They have been migrated to `ghcr.io/n4y-docker/gitlab-runner-machine-hetzner`.
 
 This repository embeds [docker-machine-driver-hetzner](https://github.com/JonasProgrammer/docker-machine-driver-hetzner) into the gitlab runner alpine docker image.


### PR DESCRIPTION
Also changes publishing to `ghcr.io/n4y-docker/gitlab-runner-machine-hetzner` instead of `ghcr.io/n4y-docker/gitlab-runner-machine-hetzner/gitlab-runner-machine-hetzner`